### PR TITLE
Etcd scale policy

### DIFF
--- a/templates/kubernetes/4/docker-compose.yml
+++ b/templates/kubernetes/4/docker-compose.yml
@@ -1,0 +1,151 @@
+kubelet:
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+        io.rancher.scheduler.global: "true"
+    command:
+        - kubelet
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --api_servers=https://kubernetes:6443
+        - --allow-privileged=true
+        - --register-node=true
+        - --cloud-provider=rancher
+        - --healthz-bind-address=0.0.0.0
+        - --cluster-dns=169.254.169.250
+        - --cluster-domain=cluster.local
+    image: rancher/k8s:v1.2.4-rancher6
+    volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - /var/run:/host/var/run
+        - /var/lib/docker:/var/lib/docker
+        - /dev:/host/dev
+    net: host
+    pid: host
+    ipc: host
+    privileged: true
+    links:
+        - kubernetes
+
+proxy:
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.scheduler.global: "true"
+    command:
+        - kube-proxy
+        - --master=http://master
+        - --v=2
+        - --healthz-bind-address=0.0.0.0
+        - --proxy-mode=userspace
+    image: rancher/k8s:v1.2.4-rancher6
+    privileged: true
+    net: host
+    links:
+        - kubernetes:master
+
+etcd:
+  image: llparse/etcd:v2.3.6-2
+  labels:
+    io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+    io.rancher.container.start_once: 'true'
+    io.rancher.sidekicks: data
+  environment:
+    ETCD_DATA_DIR: /data
+    ETCDCTL_ENDPOINT: http://etcd:2379
+    RANCHER_DEBUG: ${DEBUG}
+  links:
+  - data
+  - discovery
+  volumes_from:
+    - data
+
+data:
+  image: llparse/etcd
+  entrypoint: /bin/true
+  net: none
+  volumes:
+  - /data
+  labels:
+    io.rancher.container.start_once: 'true'
+
+kubernetes:
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    command: 
+        - kube-apiserver
+        - --service-cluster-ip-range=10.43.0.0/16
+        - --etcd-servers=http://etcd:2379
+        - --insecure-bind-address=0.0.0.0
+        - --insecure-port=80
+        - --cloud-provider=rancher
+        - --allow_privileged=true
+        - --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ResourceQuota,ServiceAccount
+        - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+        - --tls-cert-file=/etc/kubernetes/ssl/cert.pem
+        - --tls-private-key-file=/etc/kubernetes/ssl/key.pem
+    image: rancher/k8s:v1.2.4-rancher6
+    links:
+        - etcd
+
+kubectld:
+    labels:
+        io.rancher.k8s.kubectld: "true"
+    environment:
+        SERVER: http://master
+        LISTEN: ":8091"
+    image: rancher/kubectld:v0.2.0
+    links:
+        - kubernetes:master
+
+scheduler:
+    command:
+        - kube-scheduler
+        - --master=http://master
+        - --address=0.0.0.0
+    image: rancher/k8s:v1.2.4-rancher6
+    links:
+        - kubernetes:master
+
+controller-manager:
+    command:
+        - kube-controller-manager
+        - --master=https://kubernetes:6443
+        - --cloud-provider=rancher
+        - --address=0.0.0.0
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+        - --service-account-private-key-file=/etc/kubernetes/ssl/key.pem
+    image: rancher/k8s:v1.2.4-rancher6
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    links:
+        - kubernetes
+
+rancher-kubernetes-agent:
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent_service.labels_provider: "true"
+    environment:
+        KUBERNETES_URL: http://master
+    image: rancher/kubernetes-agent:v0.2.0
+    privileged: true
+    volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    links:
+        - kubernetes:master
+
+rancher-ingress-controller:
+    image: rancher/ingress-controller:v0.1.3
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environment
+    environment:
+        KUBERNETES_URL: http://master
+    command:
+        - ingress-controller
+        - --lb-controller=kubernetes
+        - --lb-provider=rancher
+    links:
+        - kubernetes:master

--- a/templates/kubernetes/4/rancher-compose.yml
+++ b/templates/kubernetes/4/rancher-compose.yml
@@ -1,0 +1,76 @@
+.catalog:
+  name: "Kubernetes"
+  version: "v1.2.4-rancher7_1"
+  description: "Rancher Kubernetes service"
+
+kubernetes:
+    metadata:
+        sans:
+        - "IP:10.43.0.1"
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 80
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+    retain_ip: true
+
+etcd:
+    scale_policy:
+        increment: 1
+        max: 3
+        min: 1
+    health_check:
+        request_line: GET /health HTTP/1.0
+        port: 2379
+        interval: 5000
+        response_timeout: 3000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+rancher-kubernetes-agent:
+    health_check:
+        request_line: GET /healthcheck HTTP/1.0
+        port: 10240
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+scheduler:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10251
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+controller-manager:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10252
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+kubectld:
+    health_check:
+        port: 8091
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+
+rancher-ingress-controller:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10241
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+

--- a/templates/kubernetes/config.yml
+++ b/templates/kubernetes/config.yml
@@ -1,5 +1,5 @@
 name: Kubernetes
 description: |
   Kubernetes service
-version: v1.2.4-rancher6_1
+version: v1.2.4-rancher7_1
 category: System


### PR DESCRIPTION
This will work in exactly 1 scenario:
start with 1 host, launch k8s, etcd passes a health check
add another host, new etcd is added and passes a health check
etc.

Scale policy must scale etcd **serially**, waiting for each new node to pass a health check (not the case in Rancher v1.1.0-rc2). Otherwise, we enter a failure scenario where mutiple etcd nodes try to dynamically add themselves at the same time, which is not supported by etcd.

We do not need a discovery etcd node because we start with a functioning 1-node cluster and dynamically reconfigure. At the expense of initializing a little slower, the transition from non-HA -> HA is automated and we no longer have to document minimum number of host requirements